### PR TITLE
add search resource property

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -6,3 +6,4 @@ github.com/hashicorp/raft 1f230096d08c6e6a039048f38ba04da329c22cf3
 github.com/hashicorp/raft-boltdb d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee
 github.com/julienschmidt/httprouter 6aacfd5ab513e34f7e64ea9627ab9670371b34e7
 github.com/lodastack/log 191ab4e8e96ed4b6c28f090dfae893646abda6c8
+github.com/satori/go.uuid 879c5887cd475cd7864858769793b2ceb0d44feb

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ dep:fmt
 	go get github.com/BurntSushi/toml
 	go get github.com/hashicorp/raft-boltdb
 	go get github.com/julienschmidt/httprouter
+	go get github.com/satori/go.uuid
 
 build: fmt 
 	cd cmd/registry && go build -v

--- a/cluster/handler.go
+++ b/cluster/handler.go
@@ -117,6 +117,11 @@ func (s *Service) View(bucket, key []byte) ([]byte, error) {
 	return s.store.View(bucket, key)
 }
 
+// TODO: Get buckets list by search ns.
+func searchBucket(node []byte) []string {
+	return []string{string(node)}
+}
+
 // Update will update the value of the given key in bucket via the cluster.
 func (s *Service) Update(bucket []byte, key []byte, value []byte) error {
 	// Try the local store. It might be the leader.

--- a/model/resource.go
+++ b/model/resource.go
@@ -1,0 +1,209 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/satori/go.uuid"
+)
+
+// data format:
+// map1uuid 1 map1key1 0 map1value1 00 map1key2 0 map1value2 000 map2uuid 1 map2key1 0 map2value1 00 map2key2 0 map2value2
+// todo: use other utf8 byte delimiter to change deliProp/deliRes; end map with delimiter
+
+const (
+	idKey      = "_id"
+	Prefix int = iota
+	Surffix
+)
+
+var (
+	deliVal  []byte = []byte{1}
+	deliProp []byte = []byte{1, 1}
+	deliRes  []byte = []byte{1, 1, 1}
+
+	uuidByte byte = 0
+	deliByte byte = 1
+	endByte  byte = 2
+)
+
+const (
+	kPosi int = iota
+	vPosi
+)
+
+// ResAction is the interface that resources Marshal and Unmarshal method.
+type ResAction interface {
+	Marshal() ([]byte, error)
+	Unmarshal(raw []byte) error
+}
+
+type Resources []Resource
+
+type Resource map[string]string
+
+func NewResources(byteData []byte) (*Resources, error) {
+	rs := &Resources{}
+	resMaps := []map[string]string{}
+	if err := json.Unmarshal(byteData, &resMaps); err != nil {
+		return rs, fmt.Errorf("marshal bytes to map fail: %s", err.Error())
+	}
+
+	*rs = make([]Resource, 0)
+	for _, resMap := range resMaps {
+		*rs = append(*rs, Resource(resMap))
+	}
+	return rs, nil
+}
+
+func NewResourcesMaps(resMaps []map[string]string) (*Resources, error) {
+	rs := &Resources{}
+	*rs = make([]Resource, 0)
+	for _, resMap := range resMaps {
+		*rs = append(*rs, Resource(resMap))
+	}
+	return rs, nil
+}
+
+// Unmarshal the byte format data and stores the result
+// in the value pointed to Resources.
+func (rs *Resources) Unmarshal(raw []byte) error {
+	*rs = make([]Resource, 0)
+	startPos, endPos := 0, 0
+	deliLen := 0
+
+	for index, byt := range raw {
+		switch byt {
+		case deliByte:
+			// Count length of deliByte.
+			deliLen++
+		case endByte:
+			//  End of resources.
+			r := Resource{}
+			if err := r.Unmarshal(raw[startPos : endPos-len(deliRes)+1]); err != nil {
+				return fmt.Errorf("unmarshal byte to resource fail")
+			} else {
+				*rs = append(*rs, r)
+			}
+			goto END
+		default:
+			if deliLen != 0 {
+				switch deliLen {
+				// TODO: length or another utf8 byte.
+				case len(deliRes):
+					endPos = index
+					r := Resource{}
+					if err := r.Unmarshal(raw[startPos : endPos-len(deliRes)+1]); err != nil {
+						return fmt.Errorf("unmarshal byte to resource fail")
+					} else {
+						*rs = append(*rs, r)
+					}
+				}
+				deliLen = 0
+			}
+		}
+	}
+END:
+	return nil
+}
+
+// Marshal returns the byte format data of Resources.
+func (rs *Resources) Marshal() ([]byte, error) {
+	raw := make([]byte, 0)
+	for _, resource := range *rs {
+		resourceByte, err := resource.Marshal()
+		if err != nil {
+			return raw, err
+		}
+		raw = append(raw, resourceByte...)
+		raw = append(raw, deliRes...)
+	}
+	raw[len(raw)-len(deliRes)] = endByte
+	return raw[0 : len(raw)-len(deliRes)+1], nil
+}
+
+func (rs *Resources) AppendResource(resByte []byte) error {
+	r := Resource{}
+	if err := r.Unmarshal(resByte); err != nil {
+		return fmt.Errorf("unmarshal resource fail")
+	}
+	(*rs) = append((*rs), r)
+	return nil
+}
+
+func (r *Resource) Unmarshal(raw []byte) error {
+	tmpk, tmpv := make([]byte, 0), make([]byte, 0)
+	kvFlag := kPosi
+	deliLen := 0
+
+	for _, byt := range raw {
+		switch byt {
+		case uuidByte:
+			// The key readed is uuid.
+			(*r)[idKey] = string(tmpk)
+			tmpk = make([]byte, 0)
+		case deliByte:
+			// Count length of deliByte.
+			deliLen++
+		default:
+			if deliLen != 0 {
+				switch deliLen {
+				case len(deliVal):
+					if kvFlag == kPosi {
+						kvFlag = vPosi
+					} else {
+						return fmt.Errorf("unmarshal resources fail")
+					}
+				case len(deliProp):
+					kvFlag = kPosi
+					(*r)[string(tmpk)] = string(tmpv)
+					tmpk, tmpv = make([]byte, 0), make([]byte, 0)
+				}
+				deliLen = 0
+			}
+			if kvFlag == kPosi {
+				tmpk = append(tmpk, byt)
+			} else {
+				tmpv = append(tmpv, byt)
+			}
+		}
+	}
+	(*r)[string(tmpk)] = string(tmpv)
+	return nil
+}
+
+// Marshal return byte of resource
+func (r *Resource) Marshal() ([]byte, error) {
+	raw := make([]byte, 0)
+	uuidStr, ok := (*r)[idKey]
+	uuid := []byte{}
+	if ok {
+		uuid = append([]byte(uuidStr), uuidByte)
+	} else {
+		uuid = append([]byte(genUUID()), uuidByte)
+	}
+	raw = append(raw, uuid...)
+
+	delete(*r, idKey)
+	for k, v := range *r {
+		raw = append(raw, []byte(k)...)
+		raw = append(raw, deliVal...)
+		raw = append(raw, []byte(v)...)
+		raw = append(raw, deliProp...)
+	}
+	lenTotal, lenDelli := len(raw), len(deliProp)
+	if lenTotal <= lenDelli {
+		return nil, fmt.Errorf("marshal resource fail")
+	}
+	return raw[0 : lenTotal-lenDelli], nil
+}
+
+// ReadProperty return property value value of key.
+func (r *Resource) ReadProperty(key string) (string, bool) {
+	v, ok := (*r)[key]
+	return v, ok
+}
+
+func genUUID() string {
+	return uuid.NewV4().String()
+}

--- a/model/resource_test.go
+++ b/model/resource_test.go
@@ -1,0 +1,108 @@
+package model
+
+import (
+	"testing"
+)
+
+var boltByte = []byte{72, 0, 72, 72, 101, 108, 108, 111, 111, 1, 32, 112, 108, 97, 121, 103, 114, 111, 117, 110, 100, 1, 1, 72, 72, 101, 108, 108, 111, 1, 32, 112, 108, 97, 121, 103, 114, 111, 117, 110, 100, 1, 1, 1,
+	73, 0, 72, 101, 108, 108, 111, 111, 1, 32, 112, 108, 97, 121, 103, 114, 111, 117, 110, 100, 1, 1, 72, 101, 108, 108, 111, 1, 32, 112, 108, 97, 121, 103, 114, 111, 117, 110, 100, 2}
+
+var rByte = []byte{72, 73, 74, 0, 72, 72, 101, 108, 108, 111, 111, 1, 32, 112, 108, 97, 121, 103, 114, 111, 117, 110, 100, 1, 1,
+	72, 72, 101, 108, 108, 111, 1, 32, 112, 108, 97, 121, 103, 114, 111, 117, 110, 100, 2}
+
+var resMaps []map[string]string = []map[string]string{{"res_key1": "res1_v1", "res_key2": "res1_v2"}, {"res_key1": "res2_v1", "res_key2": "res2_v2", "_id": "uuid1"}}
+var resByte = []byte{91, 123, 34, 114, 101, 115, 95, 107, 101, 121, 49, 34, 58, 32, 34, 114, 101, 115, 49, 95, 118, 49, 34, 44, 32, 34, 114,
+	101, 115, 95, 107, 101, 121, 50, 34, 58, 32, 34, 114, 101, 115, 49, 95, 118, 50, 34, 125, 44, 32, 123, 34, 114, 101, 115, 95,
+	107, 101, 121, 49, 34, 58, 32, 34, 114, 101, 115, 50, 95, 118, 49, 34, 44, 32, 34, 114, 101, 115, 95, 107, 101, 121, 50, 34,
+	58, 32, 34, 114, 101, 115, 50, 95, 118, 50, 34, 44, 32, 34, 95, 105, 100, 34, 58, 32, 34, 117, 117, 105, 100, 49, 34, 125, 93}
+
+func TestRsUnmarshal(t *testing.T) {
+	boltv := Resources{}
+	if err := boltv.Unmarshal(boltByte); err != nil {
+		t.Fatalf("unmarshal fail")
+		return
+	}
+	t.Log(boltv, len(boltv))
+	if len(boltv) != 2 {
+		t.Fatalf("unmarshal fail, expect result of unmarshal have length: 2")
+	}
+	for _, resouce := range boltv {
+		t.Log("%+v", resouce)
+		if _, ok := resouce["_id"]; !ok || len(resouce) != 3 {
+			t.Fatalf("unmarshal fail, resource should have _id")
+		}
+	}
+}
+
+func TestRsMarshal(t *testing.T) {
+	ressStruct, err := NewResourcesMaps(resMaps)
+	if err != nil {
+		t.Fatalf("load map to  resources fail")
+	}
+
+	ressByte, err := ressStruct.Marshal()
+	if err != nil {
+		t.Fatalf("marshal resources fail")
+	}
+	*ressStruct = Resources{}
+	if err := ressStruct.Unmarshal(ressByte); err != nil {
+		t.Fatalf("unmarshal fail")
+		return
+	}
+	t.Log(*ressStruct, len(*ressStruct))
+	if len(*ressStruct) != 2 {
+		t.Fatalf("unmarshal fail, expect result of unmarshal have length: 2")
+	}
+	for _, resouce := range *ressStruct {
+		_, havKey1 := resouce["res_key1"]
+		_, havKey2 := resouce["res_key2"]
+		if !havKey1 || !havKey2 {
+			t.Fatalf("unmarshal fail, resource should have _id")
+		}
+	}
+}
+
+func TestRUnmarshal(t *testing.T) {
+	r := Resource{}
+	if err := r.Unmarshal(rByte); err != nil {
+		t.Fatalf("unmarshal r fail: %s", err.Error())
+	}
+	if r[idKey] != "HIJ" || len(r) != 3 {
+		t.Fatalf("unmarshal r fail: not match with expect")
+	}
+	t.Log(r)
+}
+
+func TestLoadByte(t *testing.T) {
+	ressStruct, err := NewResources(resByte)
+	if err != nil {
+		t.Fatalf("Resources load byte fail", err.Error())
+	}
+	if len(*ressStruct) != 2 {
+		t.Fatalf("Resources load byte error: num of resource(map) not match")
+	}
+	for _, res := range *ressStruct {
+		_, key1 := res["res_key1"]
+		_, key2 := res["res_key2"]
+		if !key1 || !key2 {
+			t.Fatalf("Resources load byte error: property of resource(map) not match")
+		}
+	}
+
+}
+
+func BenchmarkUnmarshal(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		boltv := Resources{}
+		boltv.Unmarshal(boltByte)
+	}
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ressStruct, _ := NewResourcesMaps(resMaps)
+		ressStruct.Marshal()
+	}
+}

--- a/model/search.go
+++ b/model/search.go
@@ -1,0 +1,155 @@
+package model
+
+import (
+	"fmt"
+)
+
+type HandleFunc func(raw []byte) (Resources, error)
+
+type ResourceSearch struct {
+	Id    string // key of resource property
+	Key   string // search string
+	Value []byte // match prefix or Surffix
+
+	Process HandleFunc
+}
+
+func (s *ResourceSearch) Init() error {
+	lenId := len(s.Id)
+	lenValue := len(s.Value)
+
+	if lenValue == 0 && lenId != 0 {
+		s.Process = s.IdSearch
+	} else if lenValue != 0 {
+		s.Process = s.ValueSearch
+	} else {
+		return fmt.Errorf("none value to search")
+	}
+	return nil
+}
+
+func (s *ResourceSearch) IdSearch(raw []byte) (Resources, error) {
+	matchReses := Resources{}
+	kvFlag, deliLen := kPosi, 0
+	startPos, endPos := 0, 0
+	matchFlag := false
+	tmpk := make([]byte, 0)
+
+	for index, byt := range raw {
+		switch byt {
+		case uuidByte:
+			if s.Id == string(tmpk) {
+				matchFlag = true
+			}
+			tmpk = make([]byte, 0)
+		case deliByte:
+			// Count length of deliByte.
+			deliLen++
+		case endByte:
+			//  End of resources.
+			if matchFlag {
+				if err := matchReses.AppendResource(raw[startPos:]); err != nil {
+					return matchReses, fmt.Errorf("unmarshal resource fail")
+				}
+			}
+			goto END
+		default:
+			if deliLen != 0 {
+				switch deliLen {
+				case len(deliRes):
+					if matchFlag {
+						endPos = index - 3
+						if err := matchReses.AppendResource(raw[startPos : endPos+1]); err != nil {
+							return matchReses, fmt.Errorf("unmarshal resource fail")
+						}
+					}
+					tmpk = make([]byte, 0)
+					matchFlag = false
+					startPos = index
+					kvFlag = kPosi
+				}
+				deliLen = 0
+			}
+			if kvFlag == kPosi {
+				tmpk = append(tmpk, byt)
+			}
+		}
+	}
+END:
+	return matchReses, nil
+}
+
+func (s *ResourceSearch) ValueSearch(raw []byte) (Resources, error) {
+	matchReses := Resources{}
+	tmpk := make([]byte, 0)
+	kvFlag, deliLen, matchPos := kPosi, 0, 0
+	startPos, endPos := 0, 0
+	matchFlag := false  // flag of the k-v in the resource(map) is matched
+	matchValue := false // flag of key is matched
+
+	for ind, byt := range raw {
+		switch byt {
+		case uuidByte:
+			tmpk = make([]byte, 0)
+		case deliByte:
+			// Count length of deliByte.
+			deliLen++
+		case endByte:
+			//  End of resources.
+			if matchFlag { // TODO: end bytes with a end_byte can eliminate this process.
+				if err := matchReses.AppendResource(raw[startPos:]); err != nil {
+					return matchReses, fmt.Errorf("unmarshal resource fail")
+				}
+			}
+			goto END
+		default:
+			if deliLen != 0 {
+				switch deliLen {
+				case len(deliVal):
+					if kvFlag == kPosi {
+						kvFlag = vPosi
+					} else {
+						return matchReses, fmt.Errorf("unmarshal resources fail")
+					}
+					if len(s.Key) == 0 || s.Key == string(tmpk) {
+						// If Key is not set or is matched, value of the key should be checked.
+						matchValue = true
+					}
+				case len(deliProp):
+					matchValue = false
+					kvFlag, matchPos = kPosi, 0
+					tmpk = make([]byte, 0)
+				case len(deliRes):
+					if matchFlag {
+						// The map match the search, append this resource to resource.
+						endPos = ind - 3
+						if err := matchReses.AppendResource(raw[startPos : endPos+1]); err != nil {
+							return matchReses, fmt.Errorf("unmarshal resource fail")
+						}
+					}
+					matchFlag, matchValue = false, false
+					startPos = ind
+					kvFlag, matchPos = kPosi, 0
+					tmpk = make([]byte, 0)
+				}
+				deliLen = 0
+			}
+
+			if kvFlag == kPosi {
+				tmpk = append(tmpk, byt)
+			} else {
+				if matchValue && s.Value[matchPos] == byt {
+					matchPos++
+					if matchPos == len(s.Value) {
+						// if the s.Value is complete matched, the map is matched.
+						matchFlag = true
+					}
+				} else {
+					matchPos = 0
+				}
+			}
+		}
+	}
+END:
+	return matchReses, nil
+}

--- a/model/search_test.go
+++ b/model/search_test.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"testing"
+)
+
+// [map[_id:uuid1 res_key1:res1_v1 res_key2:res1_v2] map[_id:uuid2 res_key1:res2_v1 res_key2:res2_v2]]
+var searchByte = []byte{117, 117, 105, 100, 49, 0, 114, 101, 115, 95, 107, 101, 121, 49, 1, 114, 101, 115, 49, 95, 118, 49, 1, 1,
+	114, 101, 115, 95, 107, 101, 121, 50, 1, 114, 101, 115, 49, 95, 118, 50, 1, 1, 1,
+	117, 117, 105, 100, 50, 0, 114, 101, 115, 95, 107, 101, 121, 49, 1, 114, 101, 115, 50, 95, 118, 49, 1, 1,
+	114, 101, 115, 95, 107, 101, 121, 50, 1, 114, 101, 115, 50, 95, 118, 50, 2}
+
+func TestIdSearch(t *testing.T) {
+	search := ResourceSearch{
+		Id: "uuid2",
+	}
+	search.Init()
+	ressStruct := Resources{}
+	if err := ressStruct.Unmarshal(searchByte); err != nil {
+		t.Fatalf("Resources load byte fail: %s", err.Error())
+	}
+	t.Log(ressStruct)
+	result, err := search.Process(searchByte)
+	t.Log("search id uuid2 result:", result)
+	if err != nil || len(result) == 0 || result[0]["_id"] != "uuid2" {
+		t.Fatal("id search result not match: ", err)
+	}
+}
+
+func TestValueSearchEmptyKey(t *testing.T) {
+	search := ResourceSearch{
+		Value: []byte("res1_v2"),
+	}
+	search.Init()
+	ressStruct := Resources{}
+	if err := ressStruct.Unmarshal(searchByte); err != nil {
+		t.Fatalf("Resources load byte fail: %s", err.Error())
+	}
+	t.Log(ressStruct)
+	result, err := search.Process(searchByte)
+	t.Log("search v uuid2 result:", result)
+	if err != nil || len(result) == 0 || result[0]["_id"] != "uuid1" || result[0]["res_k2"] == "res1_v2" {
+		t.Fatal("value search result not match: ", err)
+	}
+}
+
+func TestValueSearchHasKey(t *testing.T) {
+	ressStruct := Resources{}
+	if err := ressStruct.Unmarshal(searchByte); err != nil {
+		t.Fatalf("Resources load byte fail: %s", err.Error())
+	}
+	t.Log(ressStruct)
+
+	// case 1
+	search := ResourceSearch{
+		Key:   "res_key2",
+		Value: []byte("res2_v2"),
+	}
+	search.Init()
+	result, err := search.Process(searchByte)
+	t.Log("search k-v uuid2 result:", result)
+	if err != nil || len(result) == 0 || result[0]["_id"] != "uuid2" || result[0]["res_k2"] == "res2_v2" {
+		t.Fatal("key-value search result not match: ", err)
+	}
+
+	// case 2
+	search = ResourceSearch{
+		Key:   "res_key2",
+		Value: []byte("res1_v2"),
+	}
+	search.Init()
+	result, err = search.Process(searchByte)
+	t.Log("search k-v uuid2 result:", result)
+	if err != nil || len(result) == 0 {
+		t.Fatal("key-value search result not match: ", err)
+	}
+	if result[0]["_id"] != "uuid1" || result[0]["res_k2"] == "res1_v2" {
+		t.Fatal("key-value search result not match: ", err)
+	}
+
+	// case 3
+	search = ResourceSearch{
+		Key:   "res_key3",
+		Value: []byte("res2_v2"),
+	}
+	search.Init()
+	result, err = search.Process(searchByte)
+	t.Log("search k-v uuid2 result:", result)
+	if len(result) != 0 {
+		t.Fatal("key-value search result not match: ", err)
+	}
+
+	// case 4
+	search = ResourceSearch{
+		Key:   "res_key2",
+		Value: []byte("res2_v3"),
+	}
+	search.Init()
+	result, err = search.Process(searchByte)
+	t.Log("search k-v uuid2 result:", result)
+	if len(result) != 0 {
+		t.Fatal("key-value search result not match: ", err)
+	}
+}


### PR DESCRIPTION
1. add resource model
2. add search to store/cluster
3. add search api

clear log

先写了一个初版，大家讨论

a.  一个bucket是一个节点，下面存储各种资源。
b. 各种资源以不同的字符串开头用于搜索的时候定位资源。比如机器资源可能是machine开头，监控资源以monit开头。这样我搜索监控资源的时候可以直接定位到monit开头的key，然后进行读取和搜索。
c.  保留了以下能力，待大家讨论确定方案：
         (1). 保留匹配节点列表，用于在某种节点（bucket）下进行搜索（比如在某个业务、服务下进行搜索，可以直接缩小搜索范围）；
         (2). 可以指定key的开头进行搜索，用于保留对节点下某类资源（监控，key为monit.xxxx） 或 特定资源（内存监控，key为monit.mem.xxxx）进行匹配；
         (3). 匹配资源属性可以正则、字符串匹配；
