### PR TITLE
fix store cache bug

### DIFF
--- a/store/cache.go
+++ b/store/cache.go
@@ -67,14 +67,7 @@ func (c *Cache) Purge() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for bucket, keys := range c.items {
-		for k, v := range keys {
-			if c.onEvict != nil {
-				c.onEvict([]byte(bucket), []byte(k), v.Value.(*entry).value)
-			}
-			delete(c.items, string(bucket))
-		}
-	}
+	c.items = make(map[string]map[string]*list.Element)
 	c.count = 0
 	c.size = 0
 	c.evictList.Init()

--- a/store/store.go
+++ b/store/store.go
@@ -208,6 +208,7 @@ func (s *Store) Open(enableSingle bool) error {
 		return fmt.Errorf("new raft: %s", err)
 	}
 	s.raft = ra
+	s.cache.Open()
 	s.logger.Printf("open store finished")
 	return nil
 }
@@ -721,7 +722,8 @@ func (f *fsm) applyUpdate(sub json.RawMessage) error {
 		err := b.Put(rows[0].Key, rows[0].Value)
 
 		// remove cache at last
-		f.cache.Remove(rows[0].Bucket, rows[0].Key)
+		// boltDB.Put will affect cache items, so clean all
+		f.cache.Purge()
 		return err
 	})
 }


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass

@ianwoolf 报告了一个cache的bug，经过研究发现这个bug是boltDB Put的时候会引发cache内容错乱，后来尝试换了一个cache，问题仍然存在。

解决：在调用完boltDB的Put之后，把cache清空，考虑到业务场景是读多写少，应该问题不大。

@lodastack/developers
