### PR TITLE
fix bug: still has endByte when delete all resource

### DIFF
--- a/model/resource.go
+++ b/model/resource.go
@@ -184,7 +184,7 @@ func DeleteResource(rsByte []byte, ID string) ([]byte, error) {
 			output = append(output, rByte...)
 		}
 
-		if last {
+		if last && len(output) > 0 {
 			output = append(output, endByte)
 		}
 		return output, nil

--- a/model/resource_test.go
+++ b/model/resource_test.go
@@ -236,6 +236,10 @@ func TestDeleteResource(t *testing.T) {
 	if err := rl.Unmarshal(newResByte); err != nil || len(*rl) != 1 || (*rl)[0][IdKey] != "I" {
 		t.Fatalf("delete not expect with expect, error: %v, resource: %+v", err, *rl)
 	}
+	newResByte, err = DeleteResource(newResByte, "I")
+	if err != nil || len(newResByte) != 0 {
+		t.Fatalf("Delete all Resource error, byte length:%d, error: %v", len(newResByte), err)
+	}
 
 	newResByte, err = DeleteResource(boltByte, "I")
 	if err != nil {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass


@lodastack/developers

