### PR TITLE
fix not set enable

### DIFF
--- a/model/alarm.go
+++ b/model/alarm.go
@@ -110,9 +110,14 @@ func NewAlarmByRes(ns string, data Resource, ID string) (*AlarmResource, error) 
 	} else {
 		alarm.SetID(common.GenUUID())
 	}
+	if enable, _ := data["enable"]; enable == "false" {
+		alarm.DisableSelf()
+	}
+	if isNsAdminGroup, _ := data["default"]; isNsAdminGroup == "true" {
+		alarm.SetDefault()
+	}
 
 	function, _ := data["function"]
-
 	measurement, _ := data["measurement"]
 	period, _ := data["period"]
 	where, _ := data["where"]


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass


@lodastack/developers

alarm resource enable/default default value is "enable"/"false". 